### PR TITLE
YOR-6: Add Content Type filter to Search Page

### DIFF
--- a/components/02-molecules/search-result/_yds-search-result.scss
+++ b/components/02-molecules/search-result/_yds-search-result.scss
@@ -8,9 +8,51 @@
 }
 
 .search-form--page {
+  align-items: flex-end;
   display: flex;
-  gap: var(--size-spacing-5);
+  flex-wrap: wrap;
+  gap: var(--size-spacing-6);
   margin-bottom: var(--size-spacing-8);
+
+  .form-item__textfield,
+  .form-item__dropdown,
+  .cta {
+    height: 3.125rem; // 50px.
+  }
+
+  .form-item {
+    flex: 0 0 100%;
+  }
+
+  .form-item__select {
+    min-width: 100%;
+  }
+
+  @media (min-width: tokens.$break-m) {
+    flex-wrap: nowrap;
+    gap: var(--size-spacing-5);
+
+    .form-item {
+      flex: 1;
+    }
+  }
+}
+
+.form-item--search {
+  position: relative;
+
+  .form-text {
+    padding-right: var(--size-spacing-8); // Get space for the search icon.
+  }
+
+  .form-item__icon {
+    position: absolute;
+    right: 10px;
+    height: 1.25rem;
+    width: 1.25rem;
+    top: 100%;
+    margin-top: -2.1875rem; // 35px, consider the form item height of 50px.
+  }
 }
 
 .search-result {


### PR DESCRIPTION
## [YOR-6: Add Content Type filter to Search Page](https://ffwagency.atlassian.net/browse/YOR-6)

### Description of work
- Update styles for the page search form per the new design.

### Testing Link(s)
The page search form is not presented in Storybook. The style testing needs to be done on the Drupal site. 

### Design Review
- [ ] Verify the designs match the [Figma Designs](https://www.figma.com/design/7dxhigoRGh80M0EOZ3wONc/Design?node-id=1390-4126&t=n2OeRfpi2ItdVmBe-0)

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
