### PR TITLE
YOR-33: Add Categories and Tags to Results Cards

### DIFF
--- a/components/01-atoms/lists/_yds-list.scss
+++ b/components/01-atoms/lists/_yds-list.scss
@@ -1,3 +1,5 @@
+@use '../../00-tokens/tokens';
+
 @mixin reset {
   list-style: none;
   margin: 0;
@@ -32,4 +34,41 @@ ol {
   li {
     padding-left: var(--size-spacing-1);
   }
+}
+
+.taxonomy-list {
+  @include reset;
+
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.taxonomy-list__divider {
+  margin: 0 var(--size-spacing-3);
+
+  &:last-of-type {
+    display: none;
+  }
+}
+
+.taxonomy-list--categories {
+  @include tokens.h6-mallory-compact-medium;
+
+  color: var(--color-gray-500);
+  line-height: normal;
+  margin-bottom: var(--size-spacing-4);
+  text-transform: uppercase;
+
+  @media (min-width: tokens.$break-mobile) {
+    margin-bottom: var(--size-spacing-5);
+  }
+}
+
+.taxonomy-list--tags {
+  @include tokens.body-s;
+
+  color: tokens.$color-blue-yale;
+  font-weight: var(--font-weights-mallory-medium);
+  margin-top: var(--size-spacing-4);
+  text-transform: capitalize;
 }

--- a/components/01-atoms/lists/_yds-list.scss
+++ b/components/01-atoms/lists/_yds-list.scss
@@ -72,3 +72,7 @@ ol {
   margin-top: var(--size-spacing-4);
   text-transform: capitalize;
 }
+
+.taxonomy-list__item--more {
+  text-transform: none;
+}

--- a/components/01-atoms/lists/list.stories.js
+++ b/components/01-atoms/lists/list.stories.js
@@ -1,6 +1,10 @@
 import listTwig from './yds-list.twig';
+import listTagsTwig from './taxonomy/yds-tags-list.twig';
+import listCategoriesTwig from './taxonomy/yds-categories-list.twig';
 
 import listData from './list.yml';
+import listTagsData from './taxonomy/tags-list.yml';
+import listCategoriesData from './taxonomy/categories-list.yml';
 
 /**
  * Storybook Definition.
@@ -17,3 +21,8 @@ export const OrderedList = () => `
   ${listTwig({ list__items: listData.ordered__list__items, list__type: 'ol' })}
 </div>
 `;
+
+export const TagsList = (args) => listTagsTwig({ ...listTagsData, ...args });
+
+export const CategoriesList = (args) =>
+  listCategoriesTwig({ ...listCategoriesData, ...args });

--- a/components/01-atoms/lists/taxonomy/categories-list.yml
+++ b/components/01-atoms/lists/taxonomy/categories-list.yml
@@ -1,0 +1,4 @@
+items:
+  - content: Computer Science
+  - content: Business
+  - content: Law

--- a/components/01-atoms/lists/taxonomy/tags-list.yml
+++ b/components/01-atoms/lists/taxonomy/tags-list.yml
@@ -1,0 +1,12 @@
+items:
+  - content:
+      Public Event
+  - content:
+      Campus Event
+  - content:
+      Exhibitions
+  - content:
+      Family Programs
+  - content:
+      Readings
+url: '/'

--- a/components/01-atoms/lists/taxonomy/tags-list.yml
+++ b/components/01-atoms/lists/taxonomy/tags-list.yml
@@ -1,12 +1,7 @@
 items:
-  - content:
-      Public Event
-  - content:
-      Campus Event
-  - content:
-      Exhibitions
-  - content:
-      Family Programs
-  - content:
-      Readings
+  - content: Public Event
+  - content: Campus Event
+  - content: Exhibitions
+  - content: Family Programs
+  - content: Readings
 url: '/'

--- a/components/01-atoms/lists/taxonomy/yds-categories-list.twig
+++ b/components/01-atoms/lists/taxonomy/yds-categories-list.twig
@@ -1,0 +1,6 @@
+<ul {{ bem('taxonomy-list', ['categories'], '') }}>
+  {% for item in items %}
+    <li {{ bem('item', [], 'taxonomy-list') }}>{{ item.content }}</li>
+    <li aria-hidden="true" {{ bem('divider', [], 'taxonomy-list') }}>{{ '|' }}</li>
+  {% endfor %}
+</ul>

--- a/components/01-atoms/lists/taxonomy/yds-tags-list.twig
+++ b/components/01-atoms/lists/taxonomy/yds-tags-list.twig
@@ -1,0 +1,11 @@
+<ul {{ bem('taxonomy-list', ['tags'], '') }}>
+  {% for item in items|slice(0, 3) %}
+    <li {{ bem('item', [], 'taxonomy-list') }}>{{ item.content }}</li>
+    <li aria-hidden="true" {{ bem('divider', [], 'taxonomy-list') }}>{{ '|' }}</li>
+  {% endfor %}
+  {% if items|length > 3 %}
+    <li {{ bem('taxonomy-item', [], 'taxonomy-list') }}>
+      <a href="{{ node_url }}">{{ '+' }}{{ items|length - 3 }}</a>
+    </li>
+  {% endif %}
+</ul>

--- a/components/01-atoms/lists/taxonomy/yds-tags-list.twig
+++ b/components/01-atoms/lists/taxonomy/yds-tags-list.twig
@@ -4,8 +4,8 @@
     <li aria-hidden="true" {{ bem('divider', [], 'taxonomy-list') }}>{{ '|' }}</li>
   {% endfor %}
   {% if items|length > 3 %}
-    <li {{ bem('taxonomy-item', [], 'taxonomy-list') }}>
-      <a href="{{ node_url }}">{{ '+' }}{{ items|length - 3 }}</a>
+    <li {{ bem('item', ['more'], 'taxonomy-list') }}>
+      <a href="{{ url }}">{{ '+' }}{{ items|length - 3 }}{{ " more"|t }}</a>
     </li>
   {% endif %}
 </ul>

--- a/components/02-molecules/cards/reference-card/examples/post-card.yml
+++ b/components/02-molecules/cards/reference-card/examples/post-card.yml
@@ -2,3 +2,13 @@ reference_card__date: 2022-03-30 13:00
 reference_card__heading: Wu Tsai Institute postdocs bridge disciplines in the study of cognition
 reference_card__snippet: The Wu Tsai Institute's first postdoc cohort will study human cognition, working at the intersections of different fields of research.
 reference_card__url: 'https://google.com'
+reference_card__categories:
+  - content: Computer Science
+  - content: Business
+  - content: Law
+reference_card__tags:
+  - content: Public Event
+  - content: Campus Event
+  - content: Exhibitions
+  - content: Family Programs
+  - content: Readings

--- a/components/02-molecules/cards/reference-card/reference-card.stories.js
+++ b/components/02-molecules/cards/reference-card/reference-card.stories.js
@@ -43,7 +43,7 @@ export default {
       name: 'Categories',
       type: 'array',
       defaultValue: referenceCardData.reference_card__categories,
-      if: { arg: 'show_categories' },
+      if: { arg: 'showCategories' },
     },
     showTags: {
       name: 'Show Tags',
@@ -54,7 +54,7 @@ export default {
       name: 'Tags',
       type: 'array',
       defaultValue: referenceCardData.reference_card__tags,
-      if: { arg: 'show_tags' },
+      if: { arg: 'showTags' },
     },
     withImage: {
       name: 'With Image',

--- a/components/02-molecules/cards/reference-card/reference-card.stories.js
+++ b/components/02-molecules/cards/reference-card/reference-card.stories.js
@@ -34,6 +34,28 @@ export default {
       type: 'boolean',
       defaultValue: true,
     },
+    showCategories: {
+      name: 'Show Categories/Affiliations',
+      type: 'boolean',
+      defaultValue: false,
+    },
+    categories: {
+      name: 'Categories',
+      type: 'array',
+      defaultValue: referenceCardData.reference_card__categories,
+      if: { arg: 'show_categories' },
+    },
+    showTags: {
+      name: 'Show Tags',
+      type: 'boolean',
+      defaultValue: false,
+    },
+    tags: {
+      name: 'Tags',
+      type: 'array',
+      defaultValue: referenceCardData.reference_card__tags,
+      if: { arg: 'show_tags' },
+    },
     withImage: {
       name: 'With Image',
       type: 'boolean',
@@ -49,6 +71,10 @@ export const PostCard = ({
   collectionType,
   featured,
   withImage,
+  categories,
+  showCategories,
+  tags,
+  showTags,
 }) => `
 <div class='card-collection' data-component-width='site' data-collection-type='${collectionType}' data-collection-featured="${featured}">
   <div class='card-collection__inner'>
@@ -63,6 +89,10 @@ export const PostCard = ({
         reference_card__featured: featured ? 'true' : 'false',
         reference_card__image: withImage ? 'true' : 'false',
         reference_card__url: referenceCardData.reference_card__url,
+        reference_card__categories: categories,
+        show_categories: showCategories,
+        reference_card__tags: tags,
+        show_tags: showTags,
       })}
     </ul>
   </div>
@@ -89,6 +119,10 @@ export const EventCard = ({
   secondaryCTAURL,
   multiDayEvent,
   headingPrefix,
+  categories,
+  showCategories,
+  tags,
+  showTags,
 }) => `
 <div class='card-collection' data-component-width='site' data-collection-type='${collectionType}' data-collection-featured="${featured}">
   <div class='card-collection__inner'>
@@ -109,6 +143,10 @@ export const EventCard = ({
         reference_card__cta_secondary__href: secondaryCTAURL,
         reference_card__cta_secondary__content: secondaryCTAContent,
         multi_day_event: multiDayEvent,
+        reference_card__categories: categories,
+        show_categories: showCategories,
+        reference_card__tags: tags,
+        show_tags: showTags,
       })}
     </ul>
   </div>
@@ -153,7 +191,15 @@ EventCard.argTypes = {
   },
 };
 
-export const ProfileCard = ({ collectionType, featured, withImage }) => `
+export const ProfileCard = ({
+  collectionType,
+  featured,
+  withImage,
+  categories,
+  showCategories,
+  tags,
+  showTags,
+}) => `
 <div class='card-collection' data-component-width='site' data-collection-source='profile' data-collection-type='${collectionType}' data-collection-featured="${featured}">
   <div class='card-collection__inner'>
     <ul class='card-collection__cards'>
@@ -170,6 +216,10 @@ export const ProfileCard = ({ collectionType, featured, withImage }) => `
         reference_card__snippet:
           referenceProfileCardData.reference_card__snippet,
         reference_card__url: referenceProfileCardData.reference_card__url,
+        reference_card__categories: categories,
+        show_categories: showCategories,
+        reference_card__tags: tags,
+        show_tags: showTags,
       })}
     </ul>
   </div>

--- a/components/02-molecules/cards/reference-card/yds-reference-card.twig
+++ b/components/02-molecules/cards/reference-card/yds-reference-card.twig
@@ -1,17 +1,17 @@
 {#
- # Available Props:
- # - reference_card__image: boolean used to evaluate whether or not to show the image
- #
- # Available Variables:
- # - reference_card__overline
- # - reference_card__heading
- # - reference_card__subheading
- # - reference_card__url
- # - reference_card__snippet
- #
- # Available Blocks:
- # - reference_card__image
- #}
+# Available Props:
+# - reference_card__image: boolean used to evaluate whether or not to show the image
+#
+# Available Variables:
+# - reference_card__overline
+# - reference_card__heading
+# - reference_card__subheading
+# - reference_card__url
+# - reference_card__snippet
+#
+# Available Blocks:
+# - reference_card__image
+#}
 
 {% set reference_card__base_class = 'reference-card' %}
 {% set reference_card__image = reference_card__image|default('true') %}
@@ -32,6 +32,13 @@
         text__content: reference_card__overline,
       } %}
     {% endif %}
+    {% if show_categories %}
+      {% block reference_card__categories %}
+        {% include "@atoms/lists/taxonomy/yds-categories-list.twig" with {
+          items: reference_card__categories,
+        } %}
+      {% endblock %}
+    {% endif %}
     {% include "@atoms/typography/headings/yds-heading.twig" with {
       heading__prefix__base_class: reference_card__base_class,
       heading__prefix: reference_card__prefix,
@@ -46,6 +53,14 @@
         text__base_class: 'subheading',
         text__content: reference_card__subheading,
       } %}
+    {% endif %}
+    {% if show_tags %}
+      {% block reference_card__tags %}
+        {% include "@atoms/lists/taxonomy/yds-tags-list.twig" with {
+          items: reference_card__tags,
+          url: reference_card__url,
+        } %}
+      {% endblock %}
     {% endif %}
     {% if reference_card__snippet %}
       {% include "@atoms/typography/text/yds-text.twig" with {


### PR DESCRIPTION
## [YOR-33: Add Categories and Tags to Results Cards](https://ffwagency.atlassian.net/browse/YOR-33)

### Description of work
- Adds Categories and Tags type lists in Storybook
- Add Categories and Tags lists into Reference Cards in Event Card, Post Card, Profile Card stories.

### Testing Link(s)
- [ ] Navigate to the Storybook, test the new Lists stories, test the Event Card, Post Card, Profile Card stories changing corresponding controls.

### Design Review
- [ ] Verify the designs match the [Figma Designs](https://www.figma.com/design/7dxhigoRGh80M0EOZ3wONc/Design?node-id=1390-3233&t=qt64kUgPTmEKRhR6-0)

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
