### PR TITLE
YOR-29: Additional CTA links for Spotlight Cards

### DIFF
--- a/components/02-molecules/content-spotlight-portrait/_yds-content-spotlight-portrait.scss
+++ b/components/02-molecules/content-spotlight-portrait/_yds-content-spotlight-portrait.scss
@@ -159,10 +159,6 @@ $component-content-spotlight-port-themes: map.deep-get(
 }
 
 .content-spotlight-portrait__content {
-  .link--second {
-    margin-top: var(--size-spacing-5);
-  }
-
   @media (max-width: tokens.$break-mobile-max) {
     order: 1;
   }
@@ -221,4 +217,11 @@ $component-content-spotlight-port-themes: map.deep-get(
   > *:last-child {
     margin-bottom: 0;
   }
+}
+
+.content-spotlight-portrait__ctas {
+  align-items: flex-start;
+  display: flex;
+  flex-direction: column;
+  gap: var(--size-spacing-5);
 }

--- a/components/02-molecules/content-spotlight-portrait/yds-content-spotlight-portrait.twig
+++ b/components/02-molecules/content-spotlight-portrait/yds-content-spotlight-portrait.twig
@@ -61,19 +61,24 @@
         text__content: content_spotlight_portrait__text,
         text__blockname: content_spotlight_portrait__base_class,
       } %}
-      {# Link #}
-      {% if content_spotlight_portrait__link__content and content_spotlight_portrait__link__url %}
-        {% include "@atoms/controls/text-link/yds-text-link.twig" with {
-          link__content: content_spotlight_portrait__link__content,
-          link__url: content_spotlight_portrait__link__url,
-        } %}
-      {% endif %}
-      {% if content_spotlight_portrait__link_two__content and content_spotlight_portrait__link_two__url %}
-        {% include "@atoms/controls/text-link/yds-text-link.twig" with {
-          link__content: content_spotlight_portrait__link_two__content,
-          link__url: content_spotlight_portrait__link_two__url,
-          link__modifiers: ['second'],
-        } %}
+      {% if (content_spotlight_portrait__link__content and content_spotlight_portrait__link__url) or (content_spotlight_portrait__link_two__content and content_spotlight_portrait__link_two__url) %}
+        <div {{ bem('ctas', [], content_spotlight_portrait__base_class) }}>
+          {# Link #}
+          {% if content_spotlight_portrait__link__content and content_spotlight_portrait__link__url %}
+            {% include "@atoms/controls/text-link/yds-text-link.twig" with {
+              link__content: content_spotlight_portrait__link__content,
+              link__url: content_spotlight_portrait__link__url,
+            } %}
+          {% endif %}
+          {% if content_spotlight_portrait__link_two__content and content_spotlight_portrait__link_two__url %}
+            {% include "@atoms/controls/text-link/yds-text-link.twig" with {
+              link__content: content_spotlight_portrait__link_two__content,
+              link__url: content_spotlight_portrait__link_two__url,
+              link__modifiers: ['second'],
+            } %}
+          {% endif %}
+        </div>
+
       {% endif %}
     </div>
     {# Image #}

--- a/components/02-molecules/text-with-image/_yds-text-with-image.scss
+++ b/components/02-molecules/text-with-image/_yds-text-with-image.scss
@@ -171,18 +171,10 @@ $component-content-spotlight-themes: map.deep-get(
     [data-image-position='image-right'] & {
       grid-area: primary;
     }
-
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
   }
 
   > *:not(:last-child) {
     margin-bottom: var(--size-spacing-5);
-  }
-
-  .link--second {
-    margin-top: auto;
   }
 }
 
@@ -212,4 +204,11 @@ $component-content-spotlight-themes: map.deep-get(
   > *:last-child {
     margin-bottom: 0;
   }
+}
+
+.text-with-image__ctas {
+  align-items: flex-start;
+  display: flex;
+  flex-direction: column;
+  gap: var(--size-spacing-5);
 }

--- a/components/02-molecules/text-with-image/yds-text-with-image.twig
+++ b/components/02-molecules/text-with-image/yds-text-with-image.twig
@@ -61,19 +61,23 @@
         text__content: text_with_image__text,
         text__blockname: text_with_image__base_class,
       } %}
-      {# Link #}
-      {% if text_with_image__link__content and text_with_image__link__url %}
-        {% include "@atoms/controls/text-link/yds-text-link.twig" with {
-          link__content: text_with_image__link__content,
-          link__url: text_with_image__link__url,
-        } %}
-      {% endif %}
-      {% if text_with_image__link_two__content and text_with_image__link_two__url %}
-        {% include "@atoms/controls/text-link/yds-text-link.twig" with {
-          link__content: text_with_image__link_two__content,
-          link__url: text_with_image__link_two__url,
-          link__modifiers: ['second'],
-        } %}
+      {% if (text_with_image__link__content and text_with_image__link__url) or (text_with_image__link_two__content and text_with_image__link_two__url) %}
+        <div {{ bem('ctas', [], text_with_image__base_class) }}>
+          {# Link #}
+          {% if text_with_image__link__content and text_with_image__link__url %}
+            {% include "@atoms/controls/text-link/yds-text-link.twig" with {
+              link__content: text_with_image__link__content,
+              link__url: text_with_image__link__url,
+            } %}
+          {% endif %}
+          {% if text_with_image__link_two__content and text_with_image__link_two__url %}
+            {% include "@atoms/controls/text-link/yds-text-link.twig" with {
+              link__content: text_with_image__link_two__content,
+              link__url: text_with_image__link_two__url,
+              link__modifiers: ['second'],
+            } %}
+          {% endif %}
+        </div>
       {% endif %}
     </div>
     {# Image #}


### PR DESCRIPTION
## [YOR-29: Additional CTA links for Spotlight Cards](https://ffwagency.atlassian.net/browse/YOR-29)

### Description of work
- Adds a second link field to the Content Spotlight components in Storybook

### Testing Link(s)
- [ ] Navigate to the Storybook. Search for 'Content Spotlight' components.

### Functional Review Steps
- [ ] Verify the Content Spotlight Portrait and Content Spotlight Landscape stories provide the  Second Link Content (optional) and the styles are per the design/theme.

### Design Review
- [ ] Verify the designs match the [Figma Designs](https://www.figma.com/design/7dxhigoRGh80M0EOZ3wONc/Design?node-id=668-7301&t=NlFYLYBUqZi4on1r-0)

### Accessibility Review
- [ ] Verify the component meets Accessibility requirements
