### PR TITLE
YOR-6: Add Content Type filter to Search Page

### DIFF
--- a/components/02-molecules/search-result/_yds-search-result.scss
+++ b/components/02-molecules/search-result/_yds-search-result.scss
@@ -60,11 +60,12 @@
 
   --color-text-shadow: var(--color-basic-white);
 
-  padding: var(--size-spacing-5) 0;
+  padding: var(--size-spacing-6) 0;
   border-bottom: 1px solid var(--color-gray-300);
 
   @media (min-width: tokens.$break-mobile-max) {
     max-width: var(--size-component-layout-width-content);
+    padding: var(--size-spacing-7) 0;
   }
 
   &:hover {
@@ -91,4 +92,18 @@
 
 .search-result__teaser {
   color: var(--color-gray-600);
+
+  p:last-of-type {
+    margin-bottom: 0;
+  }
+}
+
+.search-result__content-type {
+  @include tokens.body-s;
+
+  color: tokens.$color-blue-yale;
+  font-size: 1rem;
+  font-weight: var(--font-weights-mallory-medium);
+  text-transform: capitalize;
+  margin-bottom: var(--size-spacing-3);
 }

--- a/components/02-molecules/search-result/_yds-search-result.scss
+++ b/components/02-molecules/search-result/_yds-search-result.scss
@@ -8,9 +8,51 @@
 }
 
 .search-form--page {
+  align-items: flex-end;
   display: flex;
-  gap: var(--size-spacing-5);
+  flex-wrap: wrap;
+  gap: var(--size-spacing-6);
   margin-bottom: var(--size-spacing-8);
+
+  .form-item__textfield,
+  .form-item__dropdown,
+  .cta {
+    height: 3.125rem; // 50px.
+  }
+
+  .form-item {
+    flex: 0 0 100%;
+  }
+
+  .form-item__select {
+    min-width: 100%;
+  }
+
+  @media (min-width: tokens.$break-m) {
+    flex-wrap: nowrap;
+    gap: var(--size-spacing-5);
+
+    .form-item {
+      flex: 1;
+    }
+  }
+}
+
+.form-item--search {
+  position: relative;
+
+  .form-text {
+    padding-right: var(--size-spacing-8); // Get space for the search icon.
+  }
+
+  .form-item__icon {
+    position: absolute;
+    right: 10px;
+    height: 1.25rem;
+    width: 1.25rem;
+    top: 100%;
+    margin-top: -2.1875rem; // 35px, consider the form item height of 50px.
+  }
 }
 
 .search-result {

--- a/components/02-molecules/search-result/search-result.yml
+++ b/components/02-molecules/search-result/search-result.yml
@@ -1,3 +1,4 @@
 search_result__title: 'Page title'
 search_result__highlighted: '...showing <strong>word</strong> in page result...'
 search_result__teaser: '<p>Meta text here if available. Lorem ipsum dolor amet four loko distillery typewriter twee prism. Umami pinterest knausgaard four dollar toast occupy.</p>'
+search_result__content_type: 'post'

--- a/components/02-molecules/search-result/yds-search-result.stories.js
+++ b/components/02-molecules/search-result/yds-search-result.stories.js
@@ -26,14 +26,20 @@ export default {
       type: 'string',
       defaultValue: searchResultData.search_result__teaser,
     },
+    contentType: {
+      name: 'Search Results Content Type',
+      type: 'string',
+      defaultValue: searchResultData.search_result__content_type,
+    },
   },
 };
 
-export const SearchResult = ({ heading, highlighted, teaser }) =>
+export const SearchResult = ({ heading, highlighted, teaser, contentType }) =>
   searchResultTwig({
     search_result__teaser: teaser,
     search_result__title: heading,
     search_result__url: '#',
     search_result__highlighted: highlighted,
     breadcrumbs__items: breadcrumbData.items,
+    search_result__content_type: contentType,
   });

--- a/components/02-molecules/search-result/yds-search-result.twig
+++ b/components/02-molecules/search-result/yds-search-result.twig
@@ -14,6 +14,9 @@
 
 <div {{ add_attributes(search_result__attributes) }}>
   <div {{ bem('content', [], search_result__base_class) }} data-embedded-components>
+    <div {{ bem('content-type', [], search_result__base_class) }}>
+      {{ search_result__content_type }}
+    </div>
     {% include "@atoms/typography/headings/yds-heading.twig" with {
       heading__level: '2',
       heading__blockname: search_result__base_class,


### PR DESCRIPTION
## [YOR-6: Add Content Type filter to Search Page](https://ffwagency.atlassian.net/browse/YOR-6)

### Description of work
- Render content type filter select in the search form on the search page. 
- Adjust form markup to include proper form item labels.
- Render content type label into the search result teaser.

### Functional testing Steps
-  Ensure Content is Indexed: navigate to /admin/config/search/search-api/index/node_index.
 - Ensure the Content Type filter is enabled from Views Settings -> Search configuration form: navigate to /admin/yalesites/views-settings.
 - Enable the Show the Content Type filter.
 - Select all Content Types options.
 - Go to the /search page.
 - Enter a search string in the input field.
 - Select a content type from the newly added select filter.
 - Verify that the search form renders all items per design.
 - Verify the form markup meets accessibility requirements.